### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Talk slides from GolangUK 2017.
 
-Slides are at: [slides.pdf](blob/master/slides.pdf)
+Slides are at: [slides.pdf](slides.pdf)
 
-Example Code: [example code](tree/master/example)
+Example Code: [example code](example)


### PR DESCRIPTION
@paulbellamy firstly, I loved your talk and it served as a perfect introduction to using Bazel with Go!

I find myself referring to this repo sometimes and I end up clicking on the links in the README each time -- so I thought I'll send a fix for it. :)
